### PR TITLE
Remove call to `create-token`

### DIFF
--- a/terragrunt_wrapper/__init__.py
+++ b/terragrunt_wrapper/__init__.py
@@ -220,9 +220,6 @@ def main():
             f"{TK_HOME}/test/integration/root.yaml",
             f"{TK_HOME}/environments/root.yaml",
         )
-        os.environ["GOOGLE_OAUTH_ACCESS_TOKEN"] = get_output(
-            ["create-token", "-d", f"{TK_HOME}/environments"]
-        ).strip()
         parse_input(sys.argv, get_output(["terraform", "-v"]).split("\n")[0])
     except Exception as e:
         sys.exit(e)


### PR DESCRIPTION
Google now permits service account authentication to be configured
through an environment variable, so this is no longer required:

<https://cloud.google.com/blog/topics/developers-practitioners/using-google-cloud-service-account-impersonation-your-terraform-code>